### PR TITLE
Use more lenient version selector for HHVM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "xyu/heroku-wp",
     "require": {
-        "hhvm": "3.1.0",
+        "hhvm": "~3.1",
         "WordPress/WordPress": "*",
         "wpackagist-plugin/jetpack": "~3.0",
         "wpackagist-plugin/wpro": "~1.0",


### PR DESCRIPTION
Support for 3.2.0 is coming soon, and 3.1.0 may eventually be dropped, so this is better. "Real" version selectors like this one are supported now; no more warning will occur.
