### PR TITLE
Use addons:create, addons:add deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ With the [Heroku gem](http://devcenter.heroku.com/articles/heroku-command), crea
 
 Add a database to your app
 
-    $ heroku addons:add cleardb:ignite
+    $ heroku addons:create cleardb:ignite
     > Adding cleardb:ignite on strange-turtle-1234... done, v2 (free)
     > Use `heroku addons:docs cleardb:ignite` to view documentation.
 
 Add memcache to your app
 
-    $ heroku addons:add memcachier:dev
+    $ heroku addons:create memcachier:dev
     > Adding memcachier:dev on strange-turtle-1234... done, v3 (free)
     > MemCachier: added.  Your credentials may take up to 3 minutes to sync to our servers.
     > Use `heroku addons:docs memcachier:dev` to view documentation.
@@ -186,7 +186,7 @@ By default WordPress will connect to the database unencrypted which is a potenti
 
 Add SendGrid to your app
 
-    $ heroku addons:add sendgrid:starter
+    $ heroku addons:create sendgrid:starter
     > Adding sendgrid:starter on strange-turtle-1234... done, v11 (free)
     > Use `heroku addons:docs sendgrid:starter` to view documentation.
 


### PR DESCRIPTION
This updates the heroku addons instructions in the READ.me file to use addons:create rather than addons:add, which has been deprecated.

![image](https://cloud.githubusercontent.com/assets/2078561/7785588/6d695f3c-014b-11e5-9a2c-387b50df6425.png)
https://devcenter.heroku.com/articles/managing-add-ons#creating-an-add-on