### PR TITLE
Use Bento (chef.io) Box as Base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 /bin/iron-worker.tmp
 /public.built/
 /tmp/
-/ubuntu-xenial-16.04-cloudimg-console.log
 /vendor/
 /.vagrant/

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Then you can connect using SSH with the following parameters:
 * SSH password: vagrant
 * MySQL hostname: 127.0.0.1
 * MySQL port: 3306
-* mysql user: root
+* mysql user: herokuwp
 * mysql password: password
 
 If your computer goes to sleep and vagrant is suspended abruptly

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.synced_folder ".", "/app"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.synced_folder ".", "/app"
 
+  # Use password auth
+  config.ssh.username = "vagrant"
+  config.ssh.password = "vagrant"
+
   # Manage our hostfile for us
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true

--- a/support/vagrant/install.sh
+++ b/support/vagrant/install.sh
@@ -87,7 +87,7 @@ cp -a /app/support/vagrant/root/* /
 # Build Heroku-WP
 #
 
-sudo -H -u ubuntu composer --working-dir=/app install
+sudo -H -u vagrant composer --working-dir=/app install
 
 #
 # Restart Services

--- a/support/vagrant/rebuild
+++ b/support/vagrant/rebuild
@@ -25,7 +25,7 @@ while true; do
     if [ ! -z "${NEWFILES}" ]; then
         if [ ! -f "${LOCKFILE}" ]; then
             touch "${LOCKFILE}"
-            sudo -H -u ubuntu \
+            sudo -H -u vagrant \
                 composer --working-dir="${WORKINGDIR}" install > "${OUTFILE}"
             rm "${LOCKFILE}"
         fi


### PR DESCRIPTION
It looks like the xenial box provided by Ubuntu does not conform to Vagrant
conventions for accounts. (See bug report below.) Instead we can switch to a
Vagrant box provided by chef.io which does conform and works with more
providers to boot. (See box details below.)

This should resolve #86

Bug Report:
https://bugs.launchpad.net/cloud-images/+bug/1569237
Bento Box:
https://atlas.hashicorp.com/bento/boxes/ubuntu-16.04