### PR TITLE
Install Nginx from PPA

### DIFF
--- a/support/vagrant/install.sh
+++ b/support/vagrant/install.sh
@@ -14,6 +14,12 @@ echo "###############################"
 cd /app
 
 #
+# Add Nginx:PPA To Apt
+#
+
+add-apt-repository ppa:nginx/stable -y
+
+#
 # Update Package Manager
 #
 


### PR DESCRIPTION
Installing Nginx with APT doesn't reliably install the most recent stable version. Adding the PPA to APT before the `init.sh` script runs `apt-get update` and `apt-get install nginx` will pretty much always install the most recent stable version.