### PR TITLE
One approach to using herokuwp and Advanced Custom Fields PRO

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "bento/ubuntu-16.04"
 
-  config.vm.synced_folder ".", "/app"
+  config.vm.synced_folder ".", "/app", :mount_options => ["dmode=777", "fmode=777"]
 
   # Use password auth
   config.ssh.username = "vagrant"

--- a/bin/vagrant/acf_json_rsync_back.sh
+++ b/bin/vagrant/acf_json_rsync_back.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+vagrant ssh -c "rsync -av /app/public.built/wp-content/themes/{my-theme}/acf-json/ /app/public/wp-content/themes/{my-theme}/acf-json/"

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "wpackagist-plugin/authy-two-factor-authentication": "~3",
         "wpackagist-plugin/jetpack": "~4",
         "wpackagist-plugin/sendgrid-email-delivery-simplified": "~1",
+        "advanced-custom-fields/advanced-custom-fields-pro": "~5",
 
         "predis/predis": "~1.0",
         "wp-cli/wp-cli": "^1.0"
@@ -56,7 +57,20 @@
         {
             "type": "composer",
             "url": "https://wp-cli.org/package-index"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "advanced-custom-fields/advanced-custom-fields-pro",
+                "version": "5.5.10",
+                "type": "wordpress-plugin",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://connect.advancedcustomfields.com/index.php?t=5.5.10&p=pro&a=download&k={key}"
+                }
+            }
         }
+
     ],
     "extra": {
         "installer-paths": {


### PR DESCRIPTION
I don't propose that this branch is to be merged into the main repository, but I wanted to document a few things I've found working with herokuwp and [ACF][1]. I suspect there are other ACF users out there using herokuwp.

ACF can be installed via Composer, it requires editing to the `composer.json` file which is contained here and each project's key needs to be added where `{key}` is found.

ACF needs to write to the `acf-json` directory so custom fields can be added to version control. The Vagrantfile is modified so files can be written to the directory.

The `acf-json` directory ends up in `public.built` so it must be copied back to the `public` directory to become part of version control. My solution is a script that is run on the host initiating an rsync command on the guest which copies the files back into `public` allowing them to be committed to the repository.

[1]: https://www.advancedcustomfields.com/