### PR TITLE
Check to see if heroku.com is in known hosts before continuing init.sh

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -35,6 +35,13 @@ type heroku >/dev/null 2>&1 || {
 	exit 1
 }
 
+# Check to see if heroku.com is in known_hosts
+ssh-keygen -F heroku.com > /dev/null 2>&1
+if [ "$?" = 1 ] ; then
+  echo "Make an initial SSH connection to heroku.com to add it to known_hosts"
+  exit 1
+fi
+
 # Create new app and check for success
 heroku apps:create "$1" || {
 	echo >&2 "Could not create Heroku WP app."


### PR DESCRIPTION
This is a bit of an edge case I mentioned in #103, but if someone hasn't made an initial SSH connection to heroku.com the `git push` can't be complete noninteractively and `init.sh` will fail part way through.

This edit just checks to make sure heroku.com is in known_hosts before continuing.