### PR TITLE
Set Nginx config sendfile off in Vagrant

### DIFF
--- a/support/vagrant/root/etc/nginx/sites-available/herokuwp.conf
+++ b/support/vagrant/root/etc/nginx/sites-available/herokuwp.conf
@@ -22,6 +22,8 @@ server {
 
     server_name herokuwp.local;
 
+    sendfile off;
+
     listen 80;
     listen 443 ssl;
 


### PR DESCRIPTION
I mentioned this in #105. The `sendfile off` directive should be set in the Vagrant Nginx config. Setting [sendfile](http://nginx.org/en/docs/http/ngx_http_core_module.html#sendfile) to off causes Nginx to read the file each time a request is made. This is helpful during development where frequent changes are being made.