### PR TITLE
Allow Vagrant to work if vagrant-hostmanager isn't present

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,12 @@ A Vagrant instance to run Heroku WP is included. To get up and running:
 * Install Vagrant http://www.vagrantup.com/downloads
 * Install VirtualBox https://www.virtualbox.org/wiki/Downloads
 
-To make your life easier a Vagrant plugin can be used to manage the hosts file
+To make your life easier a Vagrant plugin can be used to manage the hosts file.
 
     $ vagrant plugin install vagrant-hostmanager
+
+If you don't have vagrant-hostmanager installed you'll have to manually update
+your hostfile.
 
 Once installed `cd` into app root directory and run `$ vagrant up` (should start setting up virtual env. go grab some ☕, takes about 10 minutes)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,9 +17,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.password = "vagrant"
 
   # Manage our hostfile for us
-  config.hostmanager.enabled = true
-  config.hostmanager.manage_host = true
-  config.hostmanager.manage_guest = true
+  if Vagrant.has_plugin?("vagrant-hostmanager")
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.manage_guest = true
+  else
+    config.vm.post_up_message = "Vagrant-hostmanager is not installed. Manual update of your hostfile is required."
+  end
 
   # Keep it simple; just 1 VM for db and web
   config.vm.define "herokuwp" do |herokuwp|


### PR DESCRIPTION
I thought it would be nice if `vagrant up` worked if the vagrant-hostmanager plugin wasn't present. This update allows the Vagrantfile not to fail if the hostmanager plugin is missing. It posts a message about it as well.

On a side note, I've been having the old issue where DNS lookups are extremely slow if references to loopback IP addresses aren't all on the 127.0.0.1 line. This has caused me to stop using vagrant-hostmanager and just update my hostfile manually. I'm on macOS 10.12.3. I remember this issue on Mac from way back in the day but I hadn't seen it in a long time.