### PR TITLE
Avoid PHP 7.1 to print warnings/errors in response

### DIFF
--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -237,6 +237,11 @@ if ( isset( $_ENV['WP_DEBUG'] ) && 'TRUE' == $_ENV['WP_DEBUG'] ) {
 	define( 'WP_DEBUG_LOG', false );
 	define( 'WP_DEBUG_DISPLAY', false );
 } else {
+	ini_set( 'log_errors', 'On' );
+	ini_set( 'display_errors', 'Off' );
+	ini_set( 'error_reporting', E_ALL );
+	define( 'WP_DEBUG_LOG', true );
+	define( 'WP_DEBUG_DISPLAY', false );
 	define( 'WP_DEBUG', false );
 }
 


### PR DESCRIPTION
After the last bump to `PHP 7.*` looks like the default is to throw errors and warnings on the screen even with `WP_DEBUG` set to `false`. This PR aims to fix it.