### PR TITLE
Update WP Core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,10 @@
             "type": "package",
             "package": {
                 "name": "WordPress/WordPress",
-                "version": "4.8.3",
+                "version": "4.9.1",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/WordPress/WordPress/archive/4.8.3.zip"
+                    "url": "https://github.com/WordPress/WordPress/archive/4.9.1.zip"
                 }
             }
         },


### PR DESCRIPTION
Bumping to the most recent 4.9.1 version that fixes 4 security issues